### PR TITLE
[BE | 데이터 동기화] Redis → MySQL 일별 데이터 동기화 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ allprojects {
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
         implementation 'com.h2database:h2'
 		implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 		annotationProcessor 'org.projectlombok:lombok:1.18.38'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+        implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
         implementation 'com.h2database:h2'
 		implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 		annotationProcessor 'org.projectlombok:lombok:1.18.38'

--- a/data-process-module/src/main/java/com/example/data_process_module/DataProcessModuleApplication.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/DataProcessModuleApplication.java
@@ -2,8 +2,10 @@ package com.example.data_process_module;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DataProcessModuleApplication {
 
 	public static void main(String[] args) {

--- a/data-process-module/src/main/java/com/example/data_process_module/config/RedisConfig.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/config/RedisConfig.java
@@ -1,5 +1,10 @@
 package com.example.data_process_module.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -15,12 +20,20 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
 
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(mapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
         template.afterPropertiesSet();
+
         return template;
     }
 }

--- a/data-process-module/src/main/java/com/example/data_process_module/config/RedisConfig.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/config/RedisConfig.java
@@ -25,15 +25,15 @@ public class RedisConfig {
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
 
-        GenericJackson2JsonRedisSerializer serializer =
+        GenericJackson2JsonRedisSerializer jsonSerializer =
                 new GenericJackson2JsonRedisSerializer(mapper);
 
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(serializer);
+        template.setValueSerializer(jsonSerializer);
         template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(serializer);
-        template.afterPropertiesSet();
+        template.setHashValueSerializer(jsonSerializer);
 
+        template.afterPropertiesSet();
         return template;
     }
 }

--- a/data-process-module/src/main/java/com/example/data_process_module/config/RedisConfig.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.example.data_process_module.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/data-process-module/src/main/java/com/example/data_process_module/config/RedisConnectionTest.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/config/RedisConnectionTest.java
@@ -1,0 +1,24 @@
+package com.example.data_process_module.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisConnectionTest implements CommandLineRunner {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public void run(String... args) {
+        try {
+            redisTemplate.opsForValue().set("test:key", "hello redis");
+            Object value = redisTemplate.opsForValue().get("test:key");
+            System.out.println("✅ Redis 연결 성공: " + value);
+        } catch (Exception e) {
+            System.err.println("❌ Redis 연결 실패: " + e.getMessage());
+        }
+    }
+}

--- a/data-process-module/src/main/java/com/example/data_process_module/ingest/service/IngestService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/ingest/service/IngestService.java
@@ -23,6 +23,7 @@ public class IngestService {
 
     private final TransformService transformService;
     private final DailyCandleRepository dailyCandleRepository;
+    private final PersistService persistService;
 
     public void processDailyData(DailyDataRequest dto) {
         DailyCandleEntity newEntity = DailyCandleEntity.builder()
@@ -75,6 +76,9 @@ public class IngestService {
                 high52w,
                 low52w
         );
+
+        persistService.saveMinuteData(dto.getSymbol(), metrics);
+        log.info("[TRANSFORM] {} 1분 데이터 계산 완료 -> {}", dto.getSymbol(), metrics);
 
         log.info("[1분 데이터] symbol={}, price={}, volume={}",
                 dto.getSymbol(), dto.getPrice(), dto.getVolume());

--- a/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
@@ -3,6 +3,7 @@ package com.example.data_process_module.persist.service;
 import com.example.data_process_module.persist.entity.DailyCandleEntity;
 import com.example.data_process_module.persist.repository.DailyCandleRepository;
 import java.time.Duration;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -21,8 +22,17 @@ public class PersistService {
 
         redisTemplate.opsForValue().set(key, entity, Duration.ofHours(24));
 
-        log.info("[REDIS SAVE] {} -> {}", key, entity);
+        log.info("[REDIS SAVE] 일별 데이터 {} -> {}", key, entity);
     }
+
+    public void saveMinuteData(String ticker, Map<String, Double> metrics) {
+        String key = "minute:" + ticker;
+
+        redisTemplate.opsForValue().set(key, metrics, Duration.ofHours(2));
+
+        log.info("[REDIS SAVE] 분별 데이터 {} -> {}", key, metrics);
+    }
+
 
     public void saveDaily(DailyCandleEntity entity) {
 //        dailyRepo.save(entity);

--- a/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
@@ -54,16 +54,15 @@ public class PersistService {
             log.info("🔍 {} 타입 = {}", key, value.getClass().getName());
 
             if (value instanceof DailyCandleEntity entity) {
-                dailyRepo.save(entity);
-                log.info("[SYNC] {} -> DB 저장 완료 (Entity)", key);
+                upsertDaily(entity, key);
             } else if (value instanceof Map<?, ?> mapValue) {
                 log.info("[SYNC] {} -> Map 구조로 저장되어 있음 (LinkedHashMap)", key);
                 DailyCandleEntity entity = convertMapToEntity(mapValue);
-                dailyRepo.save(entity);
-                log.info("[SYNC] {} -> DB 저장 완료 (Map → Entity)", key);
+                upsertDaily(entity, key);
             } else {
                 log.warn("⚠️ {} -> 예기치 못한 타입: {}", key, value.getClass().getName());
             }
+
         }
     }
 
@@ -77,7 +76,13 @@ public class PersistService {
         entity.setLowPrice(getDouble(map.get("lowPrice")));
         entity.setVolume(getInt(map.get("volume")));
         entity.setRsi14(getDouble(map.get("rsi14")));
+        entity.setSma5(getDouble(map.get("sma5")));
+        entity.setSma10(getDouble(map.get("sma10")));
         entity.setSma20(getDouble(map.get("sma20")));
+        entity.setSma30(getDouble(map.get("sma30")));
+        entity.setSma50(getDouble(map.get("sma50")));
+        entity.setSma100(getDouble(map.get("sma100")));
+        entity.setSma200(getDouble(map.get("sma200")));
         entity.setBbUpper(getDouble(map.get("bbUpper")));
         entity.setBbLower(getDouble(map.get("bbLower")));
         return entity;
@@ -91,8 +96,19 @@ public class PersistService {
         return obj == null ? null : ((Number) obj).intValue();
     }
 
+    private void upsertDaily(DailyCandleEntity entity, String key) {
+        DailyCandleEntity.PK pk = new DailyCandleEntity.PK(
+                entity.getStockCode(), entity.getDate()
+        );
 
+        if (dailyRepo.existsById(pk)) {
+            log.info("[SYNC] {} -> 기존 데이터 존재, update 처리", key);
+        } else {
+            log.info("[SYNC] {} -> 신규 데이터, insert 처리", key);
+        }
 
+        dailyRepo.save(entity);
+    }
 
     public void saveDaily(DailyCandleEntity entity) {
 //        dailyRepo.save(entity);

--- a/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
@@ -2,8 +2,10 @@ package com.example.data_process_module.persist.service;
 
 import com.example.data_process_module.persist.entity.DailyCandleEntity;
 import com.example.data_process_module.persist.repository.DailyCandleRepository;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -12,6 +14,15 @@ import org.springframework.stereotype.Service;
 public class PersistService {
 
     private final DailyCandleRepository dailyRepo;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void saveDailyData(String ticker, DailyCandleEntity entity) {
+        String key = "daily:" + ticker;
+
+        redisTemplate.opsForValue().set(key, entity, Duration.ofHours(24));
+
+        log.info("[REDIS SAVE] {} -> {}", key, entity);
+    }
 
     public void saveDaily(DailyCandleEntity entity) {
 //        dailyRepo.save(entity);

--- a/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/persist/service/PersistService.java
@@ -3,7 +3,9 @@ package com.example.data_process_module.persist.service;
 import com.example.data_process_module.persist.entity.DailyCandleEntity;
 import com.example.data_process_module.persist.repository.DailyCandleRepository;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -32,6 +34,64 @@ public class PersistService {
 
         log.info("[REDIS SAVE] 분별 데이터 {} -> {}", key, metrics);
     }
+
+    public void syncDailyDataToDB() {
+        Set<String> keys = redisTemplate.keys("daily:*");
+        log.info("🔍 Redis에서 찾은 daily:* 키 목록 = {}", keys);
+
+        if (keys == null || keys.isEmpty()) {
+            log.warn("⚠️ Redis에 daily:* 키가 없습니다. (keys() 결과 비어있음)");
+            return;
+        }
+
+        for (String key : keys) {
+            Object value = redisTemplate.opsForValue().get(key);
+            if (value == null) {
+                log.warn("⚠️ {} -> Redis에서 읽은 value가 null", key);
+                continue;
+            }
+
+            log.info("🔍 {} 타입 = {}", key, value.getClass().getName());
+
+            if (value instanceof DailyCandleEntity entity) {
+                dailyRepo.save(entity);
+                log.info("[SYNC] {} -> DB 저장 완료 (Entity)", key);
+            } else if (value instanceof Map<?, ?> mapValue) {
+                log.info("[SYNC] {} -> Map 구조로 저장되어 있음 (LinkedHashMap)", key);
+                DailyCandleEntity entity = convertMapToEntity(mapValue);
+                dailyRepo.save(entity);
+                log.info("[SYNC] {} -> DB 저장 완료 (Map → Entity)", key);
+            } else {
+                log.warn("⚠️ {} -> 예기치 못한 타입: {}", key, value.getClass().getName());
+            }
+        }
+    }
+
+    private DailyCandleEntity convertMapToEntity(Map<?, ?> map) {
+        DailyCandleEntity entity = new DailyCandleEntity();
+        entity.setStockCode((String) map.get("stockCode"));
+        entity.setDate(LocalDateTime.parse((String) map.get("date")));
+        entity.setOpenPrice(getDouble(map.get("openPrice")));
+        entity.setClosePrice(getDouble(map.get("closePrice")));
+        entity.setHighPrice(getDouble(map.get("highPrice")));
+        entity.setLowPrice(getDouble(map.get("lowPrice")));
+        entity.setVolume(getInt(map.get("volume")));
+        entity.setRsi14(getDouble(map.get("rsi14")));
+        entity.setSma20(getDouble(map.get("sma20")));
+        entity.setBbUpper(getDouble(map.get("bbUpper")));
+        entity.setBbLower(getDouble(map.get("bbLower")));
+        return entity;
+    }
+
+    private Double getDouble(Object obj) {
+        return obj == null ? null : ((Number) obj).doubleValue();
+    }
+
+    private Integer getInt(Object obj) {
+        return obj == null ? null : ((Number) obj).intValue();
+    }
+
+
 
 
     public void saveDaily(DailyCandleEntity entity) {

--- a/data-process-module/src/main/java/com/example/data_process_module/scheduler/DailyIndicatorScheduler.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/scheduler/DailyIndicatorScheduler.java
@@ -13,8 +13,8 @@ public class DailyIndicatorScheduler {
 
     private final PersistService persistService;
 
-//    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+//    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void syncDailyIndicators() {
         log.info("📦 [SCHEDULER] Redis → MySQL 일별 데이터 동기화 시작");
         persistService.syncDailyDataToDB();

--- a/data-process-module/src/main/java/com/example/data_process_module/scheduler/DailyIndicatorScheduler.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/scheduler/DailyIndicatorScheduler.java
@@ -1,0 +1,23 @@
+package com.example.data_process_module.scheduler;
+
+import com.example.data_process_module.persist.service.PersistService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyIndicatorScheduler {
+
+    private final PersistService persistService;
+
+//    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    public void syncDailyIndicators() {
+        log.info("📦 [SCHEDULER] Redis → MySQL 일별 데이터 동기화 시작");
+        persistService.syncDailyDataToDB();
+        log.info("✅ [SCHEDULER] Redis → MySQL 일별 데이터 동기화 완료");
+    }
+}

--- a/data-process-module/src/main/java/com/example/data_process_module/transform/service/TransformService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/transform/service/TransformService.java
@@ -1,14 +1,22 @@
 package com.example.data_process_module.transform.service;
 
 import com.example.data_process_module.persist.entity.DailyCandleEntity;
+import com.example.data_process_module.persist.service.PersistService;
 import com.example.data_process_module.transform.util.CalculationUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class TransformService {
+
+    private final PersistService persistService;
+
     public DailyCandleEntity enrichWithIndicators(DailyCandleEntity entity,
                                                   List<Double> closePrices) {
 
@@ -25,6 +33,10 @@ public class TransformService {
         double[] boll = CalculationUtil.calculateBollinger(closePrices, 20, 2);
         entity.setBbUpper(boll[0]);
         entity.setBbLower(boll[1]);
+
+        log.info("[TRANSFORM] {} 지표 계산 완료", entity.getStockCode());
+
+        persistService.saveDailyData(entity.getStockCode(), entity);
 
         return entity;
     }


### PR DESCRIPTION
## ✅ PR 제목  
- [BE | 데이터 동기화] Redis → MySQL 일별 데이터 동기화 구현  

---

## 🔀 PR 개요  
- Redis에 캐싱된 일별 지표 데이터를 MySQL로 동기화하는 기능을 추가했습니다.  

---

## ✅ 작업 내용  
- `DailyIndicatorScheduler` 구현 → **장 마감 후 자동 동기화 스케줄링**  
- `PersistService.syncDailyDataToDB()` 추가  
  - Redis의 `daily:{stockCode}` 데이터를 MySQL에 저장  
  - 중복 데이터는 `existsById()` 검사 후 update 처리 (**upsert**)  
  - 오늘 날짜(`LocalDate.now()`) 데이터만 동기화하도록 필터링  
- `convertMapToEntity()` 확장  
  - 누락되었던 **SMA(5, 10, 30, 50, 100, 200)** 필드 매핑 추가  
- `RedisConfig` 수정  
  - `StringRedisSerializer` 적용  
  - `LocalDateTime` 직렬화 지원 (Jackson `JavaTimeModule` 등록)  

---

## 📌 관련 이슈  
- Close #5 

---

## 📸 스크린샷 
<img width="808" height="214" alt="스크린샷 2025-10-07 오후 5 27 24" src="https://github.com/user-attachments/assets/c36a4ff1-fbb8-42f9-85fd-f4d9d6dfaa10" />
