### PR TITLE
[BE | 홈화면] 히트맵 알림 조회(v.1)

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/history/controller/AlertHistoryController.java
+++ b/alert-module/src/main/java/com/example/alert_module/history/controller/AlertHistoryController.java
@@ -50,4 +50,10 @@ public class AlertHistoryController {
     }
 
 
+    @GetMapping("/heatmap")
+    public ResponseEntity<?> getHeatMap(@AuthUser Long userId) {
+        return ResponseEntity.ok(ApiResponse.success(ResponseCode.SUCCESS_ALERT_HEATMAP, alertHistoryService.getHeatMap(userId)));
+    }
+
+
 }

--- a/alert-module/src/main/java/com/example/alert_module/history/dto/AlertHeatMapDto.java
+++ b/alert-module/src/main/java/com/example/alert_module/history/dto/AlertHeatMapDto.java
@@ -1,0 +1,17 @@
+package com.example.alert_module.history.dto;
+
+import java.util.List;
+
+public class AlertHeatMapDto {
+
+    public record HeatMapAlertDto(
+            String stockCode,
+            Long alertCount,
+            Double price // null 허용 (현재 미사용)
+    ) {}
+
+    public record HeatMapResponseDto(
+            List<HeatMapAlertDto> alerts,
+            Long totalCount
+    ) {}
+}

--- a/alert-module/src/main/java/com/example/alert_module/history/repository/AlertHistoryRepository.java
+++ b/alert-module/src/main/java/com/example/alert_module/history/repository/AlertHistoryRepository.java
@@ -49,4 +49,5 @@ public interface AlertHistoryRepository extends JpaRepository<AlertHistory, Long
             @Param("end") LocalDateTime end
     );
 
+    Long countByAlertIdIn(List<Long> alertIds);
 }

--- a/common-module/src/main/java/com/example/common_service/response/ResponseCode.java
+++ b/common-module/src/main/java/com/example/common_service/response/ResponseCode.java
@@ -21,6 +21,7 @@ public enum ResponseCode {
     SUCCESS_GET_ALL_COMPANIES("SUCCESS_GET_ALERTED_COMPANIES", "전체 기업 조회에 성공하였습니다.", HttpStatus.OK),
     SUCCESS_DELETE_ALERT_COMPANY("SUCCESS_DELETE_ALERT_COMPANY", "알림 전체 삭제에 성공하였습니다.", HttpStatus.OK),
     SUCCESS_TOGGLE_ALERT_COMPANY("SUCCESS_TOGGLE_ALERT_COMPANY", "알림 전체 활성화/비활성화 성공하였습니다.", HttpStatus.OK),
+    SUCCESS_ALERT_HEATMAP("SUCCESS_ALERT_HEATMAP", "일주일동안 울린 알림 조회에 성공하였습니다.", HttpStatus.OK),
 
     USER_EXIST("USER_EXIST", "이미 존재하는 회원이 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_INPUT("INVALID_INPUT", "입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 홈화면] 히트맵 알림 조회(v.1)

---

## 🔀 PR 개요
- 일주일동안 울린 알림 빈도 수 조회 

---

## ✅ 작업 내용
- `AlertHistoryService`에 `getHeatMap` 구현
- `userId`로 `alertId `조회 -> `alertId`로 `AlertHistory`의 `count`하여 조회 
- 도합 개수 계산 

---

## 📌 관련 이슈
- Close #28 

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
