### PR TITLE
[BE | 프리셋] 프리셋 수정 API 구현

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/preset/controller/PresetController.java
+++ b/alert-module/src/main/java/com/example/alert_module/preset/controller/PresetController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,6 +49,15 @@ public class PresetController {
         return ResponseEntity.ok(ApiResponse.success("프리셋 목록 조회 성공", presets));
     }
 
+    @PutMapping("/{presetId}")
+    public ResponseEntity<ApiResponse<PresetResponse>> updatePreset(
+            @AuthUser Long userId,
+            @PathVariable Long presetId,
+            @RequestBody PresetRequest request
+    ) {
+        PresetResponse response = presetService.updatePreset(userId, presetId, request);
+        return ResponseEntity.ok(ApiResponse.success("프리셋 수정 성공", response));
+    }
 
 
 


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 프리셋] 프리셋 수정 API 구현

---

## 🔀 PR 개요
- 기존 프리셋을 수정할 수 있는 API를 추가하였습니다.

---

## ✅ 작업 내용
- `PresetController`에 `@PutMapping("/{presetId}")` 엔드포인트 추가  
- `PresetService`에 `updatePreset(Long userId, Long presetId, PresetRequest request)` 메서드 구현  
- 프리셋 제목, 활성 상태(`isActive`), 조건 리스트 수정 가능하도록 로직 작성  
- 존재하지 않는 프리셋에 대한 예외 처리(`PresetNotFoundException`) 추가  
- 테스트용 요청 DTO (`PresetRequest`) 수정 및 유효성 검증 추가  

---

## 📌 관련 이슈
- Close #25 

---


## ⚠️ 기타 사항
- 프리셋 조건 수정 시 기존 조건을 전부 삭제 후 재등록하는 방식으로 구현하였습니다.  
- 추후 부분 업데이트(PATCH) 방식으로 개선할 여지가 있습니다.
