### PR TITLE
[BE | data-process] 주식 데이터 처리 후 Redis Pub/Sub 알림 연동

### DIFF
--- a/common-module/src/main/java/com/example/common_service/config/RedisConfig.java
+++ b/common-module/src/main/java/com/example/common_service/config/RedisConfig.java
@@ -5,15 +5,21 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
+
+    private final StockUpdateListener stockUpdateListener;
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
@@ -35,5 +41,13 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(stockUpdateListener, new ChannelTopic("stock:update"));
+        return container;
     }
 }

--- a/common-module/src/main/java/com/example/common_service/config/StockUpdateListener.java
+++ b/common-module/src/main/java/com/example/common_service/config/StockUpdateListener.java
@@ -1,0 +1,21 @@
+package com.example.common_service.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockUpdateListener implements MessageListener {
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String stockCode = new String(message.getBody());
+        log.info("📡 [SUBSCRIBE] Received stock update: {}", stockCode);
+        // detectionService.detectForStock(stockCode); (다음 단계에서 연결)
+    }
+}
+

--- a/data-process-module/src/main/java/com/example/data_process_module/ingest/service/IngestService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/ingest/service/IngestService.java
@@ -6,13 +6,12 @@ import com.example.data_process_module.ingest.dto.MinuteDataRequest;
 import com.example.data_process_module.persist.entity.DailyCandleEntity;
 import com.example.data_process_module.persist.repository.DailyCandleRepository;
 import com.example.data_process_module.persist.service.PersistService;
+import com.example.data_process_module.publish.DataPublishService;
 import com.example.data_process_module.transform.service.TransformService;
 import com.example.data_process_module.transform.util.CalculationUtil;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +24,7 @@ public class IngestService {
     private final TransformService transformService;
     private final DailyCandleRepository dailyCandleRepository;
     private final PersistService persistService;
+    private final DataPublishService dataPublishService;
 
     public void processDailyData(DailyDataRequest dto) {
         DailyCandleEntity newEntity = DailyCandleEntity.builder()
@@ -99,5 +99,7 @@ public class IngestService {
                 metrics.get("diffFromHigh52wPct"),
                 metrics.get("diffFromLow52wPct")
         );
+
+        dataPublishService.publishStockUpdate(dto.getSymbol());
     }
 }

--- a/data-process-module/src/main/java/com/example/data_process_module/publish/DataPublishService.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/publish/DataPublishService.java
@@ -1,0 +1,20 @@
+package com.example.data_process_module.publish;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataPublishService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void publishStockUpdate(String stockCode) {
+        String channel = "stock:update";
+        redisTemplate.convertAndSend(channel, stockCode);
+        log.info("📤 [PUBLISH] {} -> {}", channel, stockCode);
+    }
+}


### PR DESCRIPTION
## ✅ PR 제목  
- [BE | data-process] 주식 데이터 처리 후 Redis Pub/Sub 알림 연동  

---

## 🔀 PR 개요  
- 데이터 처리 완료 시 Redis를 통해 종목 업데이트 이벤트를 발행하고, Alert 모듈에서 이를 실시간 수신하도록 연동했습니다.  

---

## ✅ 작업 내용  
- **DataPublishService**: 주식 데이터 갱신 시 `stock:update` 채널로 Redis publish 기능 추가  
- **IngestService**: 데이터 저장 이후 `publishStockUpdate()` 호출 로직 추가  
- **RedisConfig**: RedisMessageListenerContainer 설정 및 `stock:update` 채널 구독 등록  
- **StockUpdateListener**: Redis 메시지 수신 시 종목 코드 로그 출력 및 탐지 로직 트리거 준비  
- FastAPI 대신 Spring(data-process) 단에서 실시간 이벤트 발행 주체로 변경  

---

## 📌 관련 이슈  
- Close #32 

---


## ⚠️ 기타 사항  
- Alert 모듈의 탐지 서비스(`AlertDetectionService.detectForStock()`) 연결 예정  
- Redis pub/sub 이벤트 end-to-end 테스트 완료 (`📤 publish → 📡 subscribe` 로그 확인)
