### PR TITLE
[BE | indicator] SMA50-200 교차(Golden/Dead Cross) 조건 Evaluator 추가

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/ConditionType.java
+++ b/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/ConditionType.java
@@ -16,6 +16,8 @@ public enum ConditionType {
     SMA_50_DOWN,
     SMA_100_DOWN,
     SMA_200_DOWN,
+    GOLDEN_CROSS,
+    DEAD_CROSS,
 
     // price
     PRICE_ABOVE,

--- a/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/impl/SMA50200DownEvaluator.java
+++ b/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/impl/SMA50200DownEvaluator.java
@@ -1,0 +1,36 @@
+package com.example.alert_module.evaluation.evaluator.impl;
+
+import com.example.alert_module.evaluation.evaluator.ConditionType;
+import com.example.alert_module.evaluation.evaluator.ConditionTypeMapping;
+import com.example.alert_module.evaluation.evaluator.base.BaseRedisEvaluator;
+import com.example.alert_module.management.repository.AlertConditionManagerRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@ConditionTypeMapping(ConditionType.DEAD_CROSS)
+@Component
+public class SMA50200DownEvaluator extends BaseRedisEvaluator {
+
+    public SMA50200DownEvaluator(RedisTemplate<String, Object> redisTemplate,
+                             AlertConditionManagerRepository repo) {
+        super(redisTemplate, repo);
+    }
+
+    @Override
+    public boolean evaluate(Long alertId, Long conditionId, String stockCode) {
+        var manager = getManager(alertId, conditionId);
+        var daily = getDaily(stockCode);
+        if (daily == null) return false;
+
+        Double sma50 = d(daily.get("sma50"));
+        Double sma200 = d(daily.get("sma200"));
+        if (sma50 == null || sma200 == null) return false;
+
+        boolean ok = sma50 <= sma200;
+        log.info("[DEAD_CROSS] alertId={} stock={} sma50={} sma200={} → {}",
+                alertId, stockCode, String.format("%.2f", sma50), String.format("%.2f", sma200), ok ? "충족" : "미충족");
+        return ok;
+    }
+}

--- a/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/impl/SMA50200UpEvaluator.java
+++ b/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/impl/SMA50200UpEvaluator.java
@@ -1,0 +1,36 @@
+package com.example.alert_module.evaluation.evaluator.impl;
+
+import com.example.alert_module.evaluation.evaluator.ConditionType;
+import com.example.alert_module.evaluation.evaluator.ConditionTypeMapping;
+import com.example.alert_module.evaluation.evaluator.base.BaseRedisEvaluator;
+import com.example.alert_module.management.repository.AlertConditionManagerRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@ConditionTypeMapping(ConditionType.GOLDEN_CROSS)
+@Component
+public class SMA50200UpEvaluator extends BaseRedisEvaluator {
+
+    public SMA50200UpEvaluator(RedisTemplate<String, Object> redisTemplate,
+                             AlertConditionManagerRepository repo) {
+        super(redisTemplate, repo);
+    }
+
+    @Override
+    public boolean evaluate(Long alertId, Long conditionId, String stockCode) {
+        var manager = getManager(alertId, conditionId);
+        var daily = getDaily(stockCode);
+        if (daily == null) return false;
+
+        Double sma50 = d(daily.get("sma50"));
+        Double sma200 = d(daily.get("sma200"));
+        if (sma50 == null || sma200 == null) return false;
+
+        boolean ok = sma50 >= sma200;
+        log.info("[GOLDEN_CROSS] alertId={} stock={} sma50={} sma200={} → {}",
+                alertId, stockCode, String.format("%.2f", sma50), String.format("%.2f", sma200), ok ? "충족" : "미충족");
+        return ok;
+    }
+}

--- a/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/test.java
+++ b/alert-module/src/main/java/com/example/alert_module/evaluation/evaluator/test.java
@@ -17,11 +17,11 @@ public class test {
     public String testCondition() {
 
         // ▶️ 나중에 indicator가 바뀌면 여기 한 줄만 수정하면 됨
-        ConditionType type = ConditionType.VOLUME_AVG_DEV_DOWN;
+        ConditionType type = ConditionType.DEAD_CROSS;
 
         boolean result = evaluatorFactory
                 .getEvaluator(type)
-                .evaluate(20L, 108L, "005930");
+                .evaluate(20L, 130L, "005930");
 
         log.info("🔵 [{}] 결과: {}", type, result);
         return result ? "조건 충족" : "조건 불충족";


### PR DESCRIPTION
## ✅ PR 제목  
- [BE | indicator] SMA50-200 교차(Golden/Dead Cross) 조건 Evaluator 추가  

---

## 🔀 PR 개요  
- SMA50과 SMA200 이동평균선 교차를 감지하는 골든크로스 / 데드크로스 조건을 추가했습니다.  

---

## ✅ 작업 내용  
- **ConditionType**: `SMA_50_200_UP`, `SMA_50_200_DOWN` 상수 추가  
- **Evaluator**:  
  - `SMA50200UpEvaluator` → SMA50 ≥ SMA200 (골든크로스)  
  - `SMA50200DownEvaluator` → SMA50 ≤ SMA200 (데드크로스)  
- threshold 없이 상대 비교 기반으로 판단  

---

## 📌 관련 이슈  
- Close #48 
---

## ⚠️ 기타 사항  
- 각 evaluator의 로그 및 ConditionType 매핑 정상 동작 확인  
- Redis metrics에서 `sma50`, `sma200` 값이 존재하지 않을 경우 기본값 처리 예정
