### PR TITLE
[BE | 히트맵] 어제 종가 대비 오늘 시가 가격 변동률 조회 

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/history/dto/AlertHeatMapDto.java
+++ b/alert-module/src/main/java/com/example/alert_module/history/dto/AlertHeatMapDto.java
@@ -7,7 +7,7 @@ public class AlertHeatMapDto {
     public record HeatMapAlertDto(
             String stockCode,
             Long alertCount,
-            Double price // null 허용 (현재 미사용)
+            Double priceRate
     ) {}
 
     public record HeatMapResponseDto(

--- a/alert-module/src/main/java/com/example/alert_module/history/entity/DailyCandle.java
+++ b/alert-module/src/main/java/com/example/alert_module/history/entity/DailyCandle.java
@@ -1,0 +1,82 @@
+package com.example.alert_module.history.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+
+@Entity
+@Table(name = "daily_candle")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(DailyCandle.PK.class)
+public class DailyCandle {
+    @Id
+    @Column(name = "stock_code", length = 50, nullable = false)
+    private String stockCode;
+
+    @Id
+    @Column(name = "date", nullable = false)
+    private LocalDateTime date;
+
+    @Column(name = "open_price")
+    private Double openPrice;
+
+    @Column(name = "close_price")
+    private Double closePrice;
+
+    @Column(name = "high_price")
+    private Double highPrice;
+
+    @Column(name = "low_price")
+    private Double lowPrice;
+
+    @Column(name = "volume")
+    private Integer volume;
+
+    @Column(name = "rsi_14")
+    private Double rsi14;
+
+    @Column(name = "bb_upper")
+    private Double bbUpper;
+
+    @Column(name = "bb_lower")
+    private Double bbLower;
+
+    @Column(name = "sma_5")
+    private Double sma5;
+
+    @Column(name = "sma_10")
+    private Double sma10;
+
+    @Column(name = "sma_20")
+    private Double sma20;
+
+    @Column(name = "sma_30")
+    private Double sma30;
+
+    @Column(name = "sma_50")
+    private Double sma50;
+
+    @Column(name = "sma_100")
+    private Double sma100;
+
+    @Column(name = "sma_200")
+    private Double sma200;
+
+    @Transient
+    private Double avgVol20;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PK implements Serializable {
+        private String stockCode;
+        private LocalDateTime date;
+    }
+}

--- a/alert-module/src/main/java/com/example/alert_module/history/repository/DailyCandleRepository.java
+++ b/alert-module/src/main/java/com/example/alert_module/history/repository/DailyCandleRepository.java
@@ -1,0 +1,10 @@
+package com.example.alert_module.history.repository;
+
+import com.example.alert_module.history.entity.DailyCandle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface DailyCandleRepository extends JpaRepository<DailyCandle, DailyCandle.PK> {
+    DailyCandle findTopByStockCodeAndDateBeforeOrderByDateDesc(String stockCode, LocalDateTime date);
+}

--- a/common-module/src/main/java/com/example/common_service/response/ResponseCode.java
+++ b/common-module/src/main/java/com/example/common_service/response/ResponseCode.java
@@ -38,7 +38,10 @@ public enum ResponseCode {
     STOCK_NOT_FOUND("STOCK_NOT_FOUND", "해당하는 종목이 없습니다.", HttpStatus.NOT_FOUND),
     NO_EXIST_ALERT("NO_EXIST_ALERT", "삭제할 알림이 없습니다.", HttpStatus.NOT_FOUND),
 
+    NO_PREVIOUS_CANDLE("NO_PREVIOUS_CANDLE", "차트 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 히트맵] 어제 종가 대비 오늘 시가 가격 변동률 조회 

---

## 🔀 PR 개요
- 히트맵에 필요한 어제 종가 대비 오늘 시가 가격 변동률 추가 

---

## ✅ 작업 내용
- DailyCandle entity, repository 구현 후 어제 종가 대비 오늘 시가 가격 변동률 구현 

---

## 📌 관련 이슈
- Close #64 

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
