### PR TITLE
[버그수정 | 알림 관리] toggleAlert API 활성화(true) 반영 오류 수정

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/management/dto/ToggleRequest.java
+++ b/alert-module/src/main/java/com/example/alert_module/management/dto/ToggleRequest.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ToggleRequest {
-    @JsonProperty("isActived")
+    @JsonProperty("isActive")
     private boolean isActived;
 }

--- a/alert-module/src/main/java/com/example/alert_module/management/service/AlertService.java
+++ b/alert-module/src/main/java/com/example/alert_module/management/service/AlertService.java
@@ -5,15 +5,16 @@ import com.example.alert_module.common.exception.ErrorCode;
 import com.example.alert_module.management.dto.*;
 import com.example.alert_module.management.repository.*;
 import com.example.alert_module.management.entity.*;
-import jakarta.annotation.Nullable;
 import jakarta.transaction.Transactional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlertService {
@@ -267,6 +268,7 @@ public class AlertService {
 
     @Transactional
     public void toggleAlert(Long userId, Long alertId, boolean isActived) {
+        log.info("");
         Alert alert = alertRepository.findById(alertId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALERT_NOT_FOUND));
 


### PR DESCRIPTION
## ✅ PR 제목
- [버그 | 알림 관리] toggleAlert API 활성화(true) 반영 오류 수정

---

## 🔀 PR 개요
- 알림 활성/비활성 토글 API에서 **활성화 요청 시 상태가 반영되지 않던 문제를 해결**했습니다.

---

## ✅ 작업 내용
- `ToggleRequest` DTO의 필드명(`isActived`)과 요청 JSON(`isActive`) 간 불일치로 인해 `true` 값이 전달되지 않던 문제 수정  
- `@JsonProperty("isActive")` 추가하여 매핑 정상화  
- 활성화(true)/비활성화(false) 모두 정상 반영 확인 완료  
- 로그를 통해 요청값 정상 수신 여부 검증

---

## 📌 관련 이슈
- Close #68 

---

