### PR TITLE
[BE | 조건 알림 등록] 조건 알림 생성 시 stockCode가 null일 경우에도 등록 가능하도록 예외 처리

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/management/service/AlertService.java
+++ b/alert-module/src/main/java/com/example/alert_module/management/service/AlertService.java
@@ -139,7 +139,7 @@ public class AlertService {
                 throw new IllegalArgumentException("등록되지 않은 indicator: " + c.indicator());
 
             Double threshold2 = null;
-            if (isBasePriceIndicator(c.indicator())) {
+            if (isBasePriceIndicator(c.indicator()) && request.stockCode() != null) {
                 threshold2 = fetchCurrentPriceFromRedis(request.stockCode());
             }
 


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 조건 알림 등록] 조건 알림 생성 시 stockCode가 null일 경우에도 등록 가능하도록 예외 처리

---

## 🔀 PR 개요
- 조건 탐색용 알림(`isConditionSearch = true`) 생성 시 `stockCode`가 `null`일 경우 등록이 실패하던 문제를 수정했습니다.  
- Redis 현재가 조회 로직(`fetchCurrentPriceFromRedis`)을 stockCode가 있을 때만 수행하도록 변경했습니다.

---

## ✅ 작업 내용
- `AlertService.createAlert()` 내부 로직 수정  
  - `isBasePriceIndicator()` 조건에 `request.stockCode() != null` 추가  
  - stockCode가 null인 경우 Redis 조회를 건너뛰고 등록만 수행하도록 처리  
- 조건 알림(`stockCode == null`)도 정상적으로 등록되도록 예외 방지  
- 관련 로그 및 빌드 정상 동작 확인

---

## 📌 관련 이슈
- Close #90 

---


