### PR TITLE
[BE | Test] Spring 통신 점검용 PingPong API 추가

### DIFF
--- a/data-process-module/src/main/java/com/example/data_process_module/ingest/controller/PingPongController.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/ingest/controller/PingPongController.java
@@ -1,0 +1,16 @@
+package com.example.data_process_module.ingest.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test")
+public class PingPongController {
+
+    @GetMapping("/ping")
+    public ResponseEntity<String> ping() {
+        return ResponseEntity.ok("pong 🏓 from Spring");
+    }
+}


### PR DESCRIPTION
## ✅ PR 제목  
**[BE | Test] Spring 통신 점검용 PingPong API 추가**

---

## 🔀 PR 개요  
- Python ↔ Spring 간 통신 점검을 위한 간단한 핑퐁 엔드포인트 구현

---

## ✅ 작업 내용  
- [x] `GET /api/test/ping` 엔드포인트 추가  
  - 요청 시 `"pong 🏓 from Spring"` 문자열 반환  
  - Swagger에서 직접 테스트 가능  
- [x] Python 측 `/ping-to-spring` 연동 테스트 완료  

---

## 📌 관련 이슈  
- Close #95 

---

## ⚠️ 기타 사항  
- 추후 `/ping` API는 배포 환경 헬스체크 및 모듈 간 연결 확인 용도로 활용 예정
