### PR TITLE
[BE | Redis] Redis 데이터 조회 테스트 API 추가

### DIFF
--- a/data-process-module/src/main/java/com/example/data_process_module/ingest/controller/RedisDebugController.java
+++ b/data-process-module/src/main/java/com/example/data_process_module/ingest/controller/RedisDebugController.java
@@ -1,0 +1,31 @@
+package com.example.data_process_module.ingest.controller;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/redis")
+@RequiredArgsConstructor
+public class RedisDebugController {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @GetMapping("/get")
+    public ResponseEntity<String> getValue(@RequestParam String key) {
+        String value = redisTemplate.opsForValue().get(key);
+        return ResponseEntity.ok(value != null ? value : "❌ Key not found");
+    }
+
+    @GetMapping("/keys")
+    public ResponseEntity<Set<String>> getKeys() {
+        Set<String> keys = redisTemplate.keys("*");
+        return ResponseEntity.ok(keys);
+    }
+}
+


### PR DESCRIPTION
## ✅ PR 제목  
- [BE | Redis] Redis 데이터 조회 테스트 API 추가

---

## 🔀 PR 개요  
-  Redis 데이터(분봉/일봉/현재가 등)를 직접 조회할 수 있는 테스트용 API를 추가했습니다.

---

## ✅ 작업 내용  
- RedisInsight 없이도 데이터 상태를 확인할 수 있는 API 구현  
- `GET /api/redis/keys` : Redis 전체 키 목록 조회  
- `GET /api/redis/get?key={key}` : 특정 키의 value 반환  
- `StringRedisTemplate` 기반 Redis 접근 로직 작성  

---

## 📌 관련 이슈  
- Close #95 

---

