### PR TITLE
[BE | 조건 탐색] 조건별 트리거된 기업 수 조회 API 구현

### DIFF
--- a/alert-module/src/main/java/com/example/alert_module/management/controller/ConditionSearchController.java
+++ b/alert-module/src/main/java/com/example/alert_module/management/controller/ConditionSearchController.java
@@ -1,6 +1,7 @@
 package com.example.alert_module.management.controller;
 
 import com.example.alert_module.management.dto.ConditionSearchResponse;
+import com.example.alert_module.management.dto.ConditionTriggeredRes;
 import com.example.alert_module.management.service.ConditionSearchService;
 import com.example.common_service.response.ApiResponse;
 import com.example.common_service.response.ResponseCode;
@@ -38,8 +39,14 @@ public class ConditionSearchController {
     }
 
     @GetMapping("/condition/triggered")
-    public ResponseEntity<String> getTriggeredConditions(@AuthUser Long userId) {
-        conditionSearchService.logActiveConditionAlerts(userId);
-        return ResponseEntity.ok("Condition-triggered alert logs printed successfully");
+    public ResponseEntity<?> getTriggeredConditions(@AuthUser Long userId) {
+        List<ConditionTriggeredRes> results = conditionSearchService.getTriggeredConditionSummary(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ResponseCode.SUCCESS_GET_TRIGGERED_CONDITION_SUMMARY,
+                        results
+                )
+        );
     }
 }

--- a/alert-module/src/main/java/com/example/alert_module/management/dto/ConditionTriggeredRes.java
+++ b/alert-module/src/main/java/com/example/alert_module/management/dto/ConditionTriggeredRes.java
@@ -1,0 +1,11 @@
+package com.example.alert_module.management.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ConditionTriggeredRes {
+    private String conditionName;      // 조건 이름
+    private Long activeCompanyCount;   // 활성화된 기업 수
+}

--- a/alert-module/src/main/java/com/example/alert_module/management/service/ConditionSearchService.java
+++ b/alert-module/src/main/java/com/example/alert_module/management/service/ConditionSearchService.java
@@ -3,10 +3,12 @@ package com.example.alert_module.management.service;
 import com.example.alert_module.evaluation.entity.ConditionSearchResult;
 import com.example.alert_module.evaluation.repository.ConditionSearchResultRepository;
 import com.example.alert_module.management.dto.ConditionSearchResponse;
+import com.example.alert_module.management.dto.ConditionTriggeredRes;
 import com.example.alert_module.management.entity.Alert;
 import com.example.alert_module.management.entity.AlertConditionManager;
 import com.example.alert_module.management.repository.AlertConditionManagerRepository;
 import com.example.alert_module.management.repository.AlertRepository;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -155,9 +157,29 @@ public class ConditionSearchService {
         return collected;
     }
 
-    public void logActiveConditionAlerts(Long userId) {
+    public List<ConditionTriggeredRes> getTriggeredConditionSummary(Long userId) {
         List<Alert> alerts = alertRepository.findByUserIdAndStockCode(userId, null);
         log.info("[ConditionTriggerService] userId={}의 조건 탐색형 알림 개수: {}", userId, alerts.size());
-        alerts.forEach(a -> log.info("🔔 alertId={}, title={}", a.getId(), a.getTitle()));
+
+        List<ConditionTriggeredRes> responseList = new ArrayList<>();
+
+        if (alerts.isEmpty()) {
+            log.info("[ConditionTriggerService] 조건 탐색형 알림이 없습니다.");
+            return responseList;
+        }
+
+        for (Alert alert : alerts) {
+            List<ConditionSearchResult> triggeredResults =
+                    conditionSearchResultRepository.findByAlert_IdAndIsTriggeredTrue(alert.getId());
+            int triggeredCount = triggeredResults.size();
+
+            String conditionName = alert.getTitle();
+            responseList.add(new ConditionTriggeredRes(conditionName, (long) triggeredCount));
+
+            log.info("🔔 alertId={}, title={}, triggered 기업 수={}",
+                    alert.getId(), alert.getTitle(), triggeredCount);
+        }
+
+        return responseList;
     }
 }

--- a/common-module/src/main/java/com/example/common_service/response/ResponseCode.java
+++ b/common-module/src/main/java/com/example/common_service/response/ResponseCode.java
@@ -29,6 +29,7 @@ public enum ResponseCode {
     SUCCESS_GET_CURRENT_PRICE("SUCCESS_GET_CURRENT_PRICE", "주식의 현재가 조회에 성공하였습니다.", HttpStatus.OK),
 
     SUCCESS_GET_CONDITION_SEARCH_RESULTS("SUCCESS_GET_CONDITION_SEARCH_RESULTS", "조건 탐색 결과 조회에 성공하였습니다", HttpStatus.OK),
+    SUCCESS_GET_TRIGGERED_CONDITION_SUMMARY("SUCCESS_GET_TRIGGERED_CONDITION_SUMMARY","유저별 조건 알림 조회에 성공하였습니다.",HttpStatus.OK),
 
     USER_EXIST("USER_EXIST", "이미 존재하는 회원이 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_INPUT("INVALID_INPUT", "입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 조건 탐색] 조건별 트리거된 기업 수 조회 API 구현

---

## 🔀 PR 개요
- 유저의 조건 탐색형 알림에 대해 조건별 활성화된 기업 수를 반환하는 API를 구현했습니다.

---

## ✅ 작업 내용
- `AlertRepository`에서 `stock_code IS NULL`, `is_actived = TRUE` 알림 조회
- `ConditionSearchResultRepository` 활용해 `is_triggered = TRUE` 기업 수 계산
- `ConditionTriggeredRes` DTO 생성 및 데이터 매핑
- `/alerts/condition/triggered` 엔드포인트 추가 및 ApiResponse로 응답 처리

---

## 📌 관련 이슈
- Close #101 

---
